### PR TITLE
Fix lower bound on validity-time

### DIFF
--- a/fuzzy-time/fuzzy-time.cabal
+++ b/fuzzy-time/fuzzy-time.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 6469e029979ef60ea4025a3c77b68c315934bc45e576beb1ba77b9e1d70f06ee
+-- hash: 4b7454d631016e005961a3b25fd8c70409c941e88db630e3c0250f6181ced39c
 
 name:           fuzzy-time
 version:        0.2.0.0
@@ -39,5 +39,5 @@ library
     , text
     , time >=1.9
     , validity
-    , validity-time
+    , validity-time >=0.5.0.0 && <0.6
   default-language: Haskell2010

--- a/fuzzy-time/package.yaml
+++ b/fuzzy-time/package.yaml
@@ -22,4 +22,4 @@ library:
   - text
   - time >=1.9
   - validity
-  - validity-time
+  - validity-time ^>=0.5.0.0


### PR DESCRIPTION
Otherwise you get build error:

```

src/Data/FuzzyTime/Types.hs:121:9: error:
    • No instance for (Validity DayOfWeek)
        arising from a use of ‘genericValidate’
    • In the expression: genericValidate fd
      In the first argument of ‘mconcat’, namely
        ‘[genericValidate fd,
          case fd of
            OnlyDay di
              -> decorate "OnlyDay"
                   $ mconcat [declare "The day is strictly positive" $ di >= 1, ....]
            DayInMonth mi di
              -> decorate "DayInMonth"
                   $ mconcat [declare "The day is strictly positive" $ di >= 1, ....]
            _ -> valid]’
      In the expression:
        mconcat
          [genericValidate fd,
           case fd of
             OnlyDay di
               -> decorate "OnlyDay"
                    $ mconcat [declare "The day is strictly positive" $ di >= 1, ....]
             DayInMonth mi di
               -> decorate "DayInMonth"
                    $ mconcat [declare "The day is strictly positive" $ di >= 1, ....]
             _ -> valid]
    |
121 |       [ genericValidate fd,
    |         ^^^^^^^^^^^^^^^^^^
```